### PR TITLE
Basic認証導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,4 @@ gem 'pry-rails'
 group :production do
   gem 'rails_12factor'
 end
+05

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
+
+  private
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 end


### PR DESCRIPTION
#What
Basic認証の作成

#Why
Basic認証を導入し、ポートフォリオサイトへのアクセスを制限するため。